### PR TITLE
fix: allow Path instances to be added to input_file list

### DIFF
--- a/fastdup/utils.py
+++ b/fastdup/utils.py
@@ -2,6 +2,7 @@ import os
 import glob
 import random
 import platform
+from pathlib import Path
 from fastdup.definitions import *
 from datetime import datetime
 from fastdup.sentry import fastdup_capture_exception
@@ -192,8 +193,8 @@ def expand_list_to_files(the_list):
     files = []
     found = False
     for f in the_list:
-        if isinstance(f, str):
-            if f.startswith("s3://") or f.startswith("minio://"):
+        if isinstance(f, str) or isinstance(f, Path):
+            if isinstance(f, str) and (f.startswith("s3://") or f.startswith("minio://")):
                 for suffix in IMAGE_SUFFIXES:
                     if f.lower().endswith(suffix):
                         found = True


### PR DESCRIPTION
Bug:
The current implementation of utils:expand_list_to_files(...) does not handle non-string (pathlib.Path) entries in the file_list. Consequently, such entries are skipped without being processed.

Fix:
To handle non-string entries in the file_list, we have updated utils:expand_list_to_files(...) to support also Path instances

fixes #187 