### PR TITLE
Link Data Loading examples to docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ The following are community-contributed blog posts about fastdup -
 <tr>
     <td><img src="gallery/community_reduce_dataset_thumbnail.jpg" width="200"></td>
     <td>
-      <a href="https://blog.roboflow.com/how-to-reduce-dataset-size-computer-vision/amp/">Roboflow: How to Reduce Dataset Size Without Losing Accuracy</a><br>
+      <a href="https://blog.roboflow.com/how-to-reduce-dataset-size-computer-vision/">Roboflow: How to Reduce Dataset Size Without Losing Accuracy</a><br>
       🖋️ <a href="author_link_here">Arty Ariuntuya</a> &nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp; 🗓 9 August 2023
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ This notebooks in this section shows how you can load data from various sources 
                 <img src="./gallery/ninja_thumbnail.jpg" width="200" />
             </a>
         </td>
-        <td rowspan="4"><b>🏆 Kaggle:</b> Load and analyze any computer vision datasets from <a href="https://kaggle.com">Kaggle</a>. Get ahead of your competition with data insights.</td>
+        <td rowspan="4"><b>🏆 Kaggle:</b> Load and analyze any computer vision datasets from <a href="https://kaggle.com">Kaggle</a>. Get ahead of your competition with data insights.<br><br>
+        <a href="https://visual-layer.readme.io/docs/kaggle">🔗 Learn More.</a></td>
         <td align="center" width="80">
             <a href="https://nbviewer.org/github/visual-layer/fastdup/blob/main/examples/analyzing-kaggle-datasets.ipynb">
                 <img src="./gallery/nbviewer_logo.png" height="30" />
@@ -443,7 +444,8 @@ This notebooks in this section shows how you can load data from various sources 
                 <img src="./gallery/universe_thumbnail.jpg" width="200" />
             </a>
         </td>
-        <td rowspan="4"><b>🌎 Roboflow Universe:</b> Load and analyze any computer vision datasets from <a href="https://universe.roboflow.com/">Roboflow Universe</a>. Analyze any of the 200,000 datasets on Roboflow Universe.</td>
+        <td rowspan="4"><b>🌎 Roboflow Universe:</b> Load and analyze any computer vision datasets from <a href="https://universe.roboflow.com/">Roboflow Universe</a>. Analyze any of the 200,000 datasets on Roboflow Universe.<br><br>
+        <a href="https://visual-layer.readme.io/docs/roboflow-universe">🔗 Learn More.</a></td>
         <td align="center" width="80">
             <a href="https://nbviewer.org/github/visual-layer/fastdup/blob/main/examples/analyzing-roboflow-datasets.ipynb">
                 <img src="./gallery/nbviewer_logo.png" height="30" />

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ This notebooks in this section shows how you can load data from various sources 
                 <img src="./gallery/hf_thumbnail.jpg" width="200" />
             </a>
         </td>
-        <td rowspan="4"><b>🤗 Hugging Face Datasets:</b> Load and analyze datasets from <a href="https://huggingface.co/datasets">Hugging Face Datasets</a>. Perfect if you already have a dataset hosted on Hugging Face hub.</td>
+        <td rowspan="4"><b>🤗 Hugging Face Datasets:</b> Load and analyze datasets from <a href="https://huggingface.co/datasets">Hugging Face Datasets</a>. Perfect if you already have a dataset hosted on Hugging Face hub.<br><br><a href="https://visual-layer.readme.io/docs/hugging-face-datasets">🔗 Docs.</a></td>
         <td align="center" width="80">
             <a href="https://nbviewer.org/github/visual-layer/fastdup/blob/main/examples/analyzing-hf-datasets.ipynb">
                 <img src="./gallery/nbviewer_logo.png" height="30" />

--- a/README.md
+++ b/README.md
@@ -372,7 +372,10 @@ This notebooks in this section shows how you can load data from various sources 
                 <img src="./gallery/hf_thumbnail.jpg" width="200" />
             </a>
         </td>
-        <td rowspan="4"><b>🤗 Hugging Face Datasets:</b> Load and analyze datasets from <a href="https://huggingface.co/datasets">Hugging Face Datasets</a>. Perfect if you already have a dataset hosted on Hugging Face hub.<br><br><a href="https://visual-layer.readme.io/docs/hugging-face-datasets">🔗 Docs.</a></td>
+        <td rowspan="4"><b>🤗 Hugging Face Datasets:</b> Load and analyze datasets from <a href="https://huggingface.co/datasets">Hugging Face Datasets</a>. Perfect if you already have a dataset hosted on Hugging Face hub.
+        <div style="text-align: right;">
+            <a href="https://visual-layer.readme.io/docs/hugging-face-datasets">🔗 Docs.</a>
+        </div></td>
         <td align="center" width="80">
             <a href="https://nbviewer.org/github/visual-layer/fastdup/blob/main/examples/analyzing-hf-datasets.ipynb">
                 <img src="./gallery/nbviewer_logo.png" height="30" />

--- a/README.md
+++ b/README.md
@@ -372,10 +372,8 @@ This notebooks in this section shows how you can load data from various sources 
                 <img src="./gallery/hf_thumbnail.jpg" width="200" />
             </a>
         </td>
-        <td rowspan="4"><b>🤗 Hugging Face Datasets:</b> Load and analyze datasets from <a href="https://huggingface.co/datasets">Hugging Face Datasets</a>. Perfect if you already have a dataset hosted on Hugging Face hub.
-        <div style="text-align: right;">
-            <a href="https://visual-layer.readme.io/docs/hugging-face-datasets">🔗 Docs.</a>
-        </div></td>
+        <td rowspan="4"><b>🤗 Hugging Face Datasets:</b> Load and analyze datasets from <a href="https://huggingface.co/datasets">Hugging Face Datasets</a>. Perfect if you already have a dataset hosted on Hugging Face hub.<br><br>
+        <a href="https://visual-layer.readme.io/docs/hugging-face-datasets">🔗 Learn More.</a></td>
         <td align="center" width="80">
             <a href="https://nbviewer.org/github/visual-layer/fastdup/blob/main/examples/analyzing-hf-datasets.ipynb">
                 <img src="./gallery/nbviewer_logo.png" height="30" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-i
 <!-- PROJECT SHIELDS -->
 <!--
 *** I'm using markdown "reference style" links for readability.
@@ -369,7 +368,7 @@ This notebooks in this section shows how you can load data from various sources 
 <table>
     <tr>
         <td rowspan="4" width="160">
-            <a href="https://visual-layer.readme.io/docs/">
+            <a href="https://visual-layer.readme.io/docs/hugging-face-datasets">
                 <img src="./gallery/hf_thumbnail.jpg" width="200" />
             </a>
         </td>
@@ -404,7 +403,7 @@ This notebooks in this section shows how you can load data from various sources 
     <!-- ------------------------------------------------------------------- -->
     <tr>
         <td rowspan="4" width="160">
-            <a href="https://visual-layer.readme.io/docs/">
+            <a href="https://visual-layer.readme.io/docs/kaggle">
                 <img src="./gallery/ninja_thumbnail.jpg" width="200" />
             </a>
         </td>
@@ -439,7 +438,7 @@ This notebooks in this section shows how you can load data from various sources 
     <!-- ------------------------------------------------------------------- -->
     <tr>
         <td rowspan="4" width="160">
-            <a href="https://visual-layer.readme.io/docs/">
+            <a href="https://visual-layer.readme.io/docs/roboflow-universe">
                 <img src="./gallery/universe_thumbnail.jpg" width="200" />
             </a>
         </td>


### PR DESCRIPTION
This PR adds links to Data Loading examples (Hugging Face, Kaggle, and Roboflow) to the documentation page.

![image](https://github.com/visual-layer/fastdup/assets/6821286/86305d18-7552-4d54-9ed0-9a70c7b8c17d)
