### PR TITLE
Update Notebook - Run with your own feature vectors.

### DIFF
--- a/examples/feature_vectors.ipynb
+++ b/examples/feature_vectors.ipynb
@@ -13,7 +13,7 @@
    "id": "a6445d60-47e5-4f91-93cb-3da1a37bc205",
    "metadata": {},
    "source": [
-    "# Tutorial for working directly with feature vectors\n",
+    "# Run On Pre-computed Feature Vectors\n",
     "\n",
     "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/visual-layer/fastdup/blob/main/examples/feature_vectors.ipynb)\n",
     "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/visual-layer/fastdup/blob/main/examples/feature_vectors.ipynb)"
@@ -298,7 +298,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the notebook that guides users on how to run fastdup using their own feature vectors. The notebook walks through an end-to-end example where we compute the feature vectors using DINOv2s and then load it into fastdup.

Link to Colab Notebook - https://colab.research.google.com/github/visual-layer/fastdup/blob/dnth/nb-feature-vec/examples/feature_vectors.ipynb

Also updated the header and footer badges.

+ Header
![image](https://github.com/visual-layer/fastdup/assets/6821286/7bdbebf0-1f22-479f-adda-cd16af6b4d1f)

+ Footer
![image](https://github.com/visual-layer/fastdup/assets/6821286/66986e36-2af4-452e-abd1-ed40f5dc6c1d)
