### PR TITLE
Add enrichment models - Recognize Anything, Tag2text, Grounding DINO and Segment Anything Model

### DIFF
--- a/fastdup/fastdup_controller.py
+++ b/fastdup/fastdup_controller.py
@@ -1339,8 +1339,8 @@ class FastdupController:
         if num_rows:
             df = df.head(num_rows)
 
-        if task == "tagging":
-            if model=='ram':
+        if task == "zero-shot-classification":
+            if model=='recognize-anything-model':
                 from fastdup.models.ram import RecognizeAnythingModel
                 enrichment_model = RecognizeAnythingModel()
                 df['ram_tags'] = df['filename'].apply(enrichment_model.run_inference)
@@ -1353,8 +1353,8 @@ class FastdupController:
                 if user_tags != "None":
                     df['tag2text_user_caption'] = df['filename'].apply(lambda x: enrichment_model.run_inference(x, user_tags=user_tags)[2])
         
-        elif task == "grounding-object-detection":
-            if model == "grounding_dino":
+        elif task == "zero-shot-detection":
+            if model == "grounding-dino":
                 from fastdup.models.grounding_dino import GroundingDINO
                 enrichment_model = GroundingDINO()
 
@@ -1364,8 +1364,8 @@ class FastdupController:
                 
                 df['grounding_dino_bbox'], df['scores'], df['labels'] = zip(*df.apply(compute_bbox, axis=1))
 
-        elif task == "segmentation":
-            if model == "sam":
+        elif task == "zero-shot-segmentation":
+            if model == "segment-anything":
                 from fastdup.models.sam import SegmentAnythingModel 
                 import torch
                 enrichment_model = SegmentAnythingModel()
@@ -1384,7 +1384,10 @@ class FastdupController:
 
                 df['sam_masks'] = [preprocess_and_run(filename, bbox) for filename, bbox in zip(df['filename'], tensor_list)]
         
-        enrichment_model.unload_model()        
+        try:
+            enrichment_model.unload_model()  
+        except Exception as e:
+            print('Please select a valid enrichment task or model')
         return df
 
 def is_fastdup_dir(work_dir):

--- a/fastdup/fastdup_controller.py
+++ b/fastdup/fastdup_controller.py
@@ -198,50 +198,7 @@ class FastdupController:
         df_annot = self._df_annot.query(f'{FD.ANNOT_VALID}') if valid_only and self._df_annot is not None \
             else self._df_annot
         return df_annot
-
-
-    def init_search(self, k, verbose=False):
-        """
-        Initialize search
-        Args:
-            k (int): number of returned images
-            verbose (bool): verbose level
-
-        Returns:
-
-        """
-        return fastdup.init_search(k=k,
-                                   work_dir=self.config['work_dir'],
-                                   d=self.config['d'],
-                                   model_path=self.config['model_path'],
-                                   verbose=verbose
-                                   )
-
-    def search(self, filename, img=None, verbose=False):
-        '''
-           Search for similar images in the image database.
-
-           Args:
-               filename (str): full path pointing to an image.
-               img (PIL.Image): (Optional) loaded and resized PIL.Image, in case given it is not red from filename
-               verbose (bool): (Optiona) run in verbose mode, default is False
-           Returns:
-               ret (pd.DataFrame): None in case of error, otherwise a pd.DataFrame with from,to,distance columns
-           '''
-        return fastdup.search(filename=filename, img=img, verbose=verbose)
-
-    def vector_search(self, filename="query_vector", vec=None, verbose=False):
-        '''
-        Search for similar embeddings to a given vector
-
-        Args:
-            filename: vector name (used for debugging)
-            vec (numpy): Mandatory numpy matrix of size 1xd or a vector of size d
-            verbose (bool): (Optiona) run in verbose mode, default is False
-        Returns:
-            ret (pd.DataFrame): None in case of error, otherwise a pd.DataFrame with from,to,distance columns
-        '''
-        return fastdup.vector_search(filename, vec, d=self.config['d'], verbose=verbose)
+    
 
     def similarity(self, data: bool = True, split: Union[str, List[str]] = None,
                    include_unannotated: bool = False, load_crops: bool = False) -> pd.DataFrame:

--- a/fastdup/models/grounding_dino.py
+++ b/fastdup/models/grounding_dino.py
@@ -1,0 +1,207 @@
+try:
+    from mmengine.config import Config
+    from PIL import Image
+    import torch
+    import groundingdino
+    import groundingdino.datasets.transforms as T
+    from groundingdino.models import build_model
+    from groundingdino.util import get_tokenlizer
+    from groundingdino.util.utils import (clean_state_dict,
+                                        get_phrases_from_posmap)
+    grounding_dino_transform = T.Compose([
+        T.RandomResize([800], max_size=1333),
+        T.ToTensor(),
+        T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+    ])
+except ImportError as e:
+    print(e)
+    installation = 'pip install mmengine ' \
+    'groundingdino-py ' \
+    'git+https://github.com/facebookresearch/segment-anything.git ' \
+    'scipy ' \
+    'git+https://github.com/open-mmlab/mmdetection.git ' \
+
+    print(f"Please install with {installation}")
+
+
+class GroundingDINO:
+    def __init__(self, 
+                 model_config:str = "GroundingDINO_SwinT_OGC.py", 
+                 model_weights:str = "groundingdino_swint_ogc.pth", 
+                 device:str="cuda"
+                 ) -> None:
+        self.model_config = model_config
+        self.model_weights = model_weights
+        self.device = device
+        self.model = self._load_model()
+    
+    def _load_model(self):
+        gdino_args = Config.fromfile(self.model_config)
+        model = build_model(gdino_args)
+        checkpoint = torch.load(self.model_weights, map_location='cpu')
+        model.load_state_dict(clean_state_dict(checkpoint['model']), strict=False)
+        model.eval()
+        model.to(self.device)
+        return model
+    
+    def run_inference(self, image_path, text_prompt, box_threshold=0.3, text_threshold=0.25, apply_original_groudingdino=False):
+        pred_dict = {}
+        image_pil = Image.open(image_path).convert('RGB')  # load image
+        image_pil = self._apply_exif_orientation(image_pil)
+        image, _ = grounding_dino_transform(image_pil, None)  # 3, h, w
+
+        text_prompt = text_prompt.lower().strip()
+        if not text_prompt.endswith('.'):
+            text_prompt = text_prompt + '.'
+
+        # Original GroundingDINO use text-thr to get class name,
+        # the result will always result in categories that we don't want,
+        # so we provide a category-restricted approach to address this
+        if not apply_original_groudingdino:
+            custom_vocabulary = text_prompt[:-1].split('.')
+            label_name = [c.strip() for c in custom_vocabulary]
+            tokens_positive = []
+            start_i = 0
+            separation_tokens = ' . '
+            for _index, label in enumerate(label_name):
+                end_i = start_i + len(label)
+                tokens_positive.append([(start_i, end_i)])
+                if _index != len(label_name) - 1:
+                    start_i = end_i + len(separation_tokens)
+            tokenizer = get_tokenlizer.get_tokenlizer('bert-base-uncased')
+            tokenized = tokenizer(text_prompt, padding='longest', return_tensors='pt')
+            positive_map_label_to_token = self._create_positive_dict(tokenized, tokens_positive, list(range(len(label_name))))
+
+        image = image.to(next(self.model.parameters()).device)
+
+        with torch.no_grad():
+            outputs = self.model(image[None], captions=[text_prompt])
+
+        logits = outputs['pred_logits'].cpu().sigmoid()[0]
+        boxes = outputs['pred_boxes'].cpu()[0]
+
+        if not apply_original_groudingdino:
+            logits = self._convert_grounding_to_od_logits(logits, len(label_name), positive_map_label_to_token)
+
+        logits_filt = logits.clone()
+        boxes_filt = boxes.clone()
+        filt_mask = logits_filt.max(dim=1)[0] > box_threshold
+        logits_filt = logits_filt[filt_mask]
+        boxes_filt = boxes_filt[filt_mask]
+
+        if apply_original_groudingdino:
+            tokenlizer = self.model.tokenizer
+            tokenized = tokenlizer(text_prompt)
+            pred_labels = []
+            pred_scores = []
+            for logit, box in zip(logits_filt, boxes_filt):
+                pred_phrase = get_phrases_from_posmap(logit > text_threshold, tokenized, tokenlizer)
+                pred_labels.append(pred_phrase)
+                pred_scores.append(round(float(score.item()), 4))
+
+        else:
+            scores, pred_phrase_idxs = logits_filt.max(1)
+            pred_labels = []
+            pred_scores = []
+            for score, pred_phrase_idx in zip(scores, pred_phrase_idxs):
+                pred_labels.append(label_name[pred_phrase_idx])
+                pred_scores.append(round(float(score.item()), 4))
+
+        pred_dict['labels'] = pred_labels
+        pred_dict['scores'] = pred_scores
+
+        size = image_pil.size
+        H, W = size[1], size[0]
+        for i in range(boxes_filt.size(0)):
+            boxes_filt[i] = boxes_filt[i] * torch.Tensor([W, H, W, H])
+            boxes_filt[i][:2] -= boxes_filt[i][2:] / 2
+            boxes_filt[i][2:] += boxes_filt[i][:2]
+        
+        pred_dict['boxes'] = [tuple(round(coord, 2) for coord in box) for box in boxes_filt.tolist()]
+
+
+        return pred_dict
+    def _convert_grounding_to_od_logits(self, logits,
+                                    num_classes,
+                                    positive_map,
+                                    score_agg='MEAN'):
+        """
+        logits: (num_query, max_seq_len)
+        num_classes: 80 for COCO
+        """
+        assert logits.ndim == 2
+        assert positive_map is not None
+        scores = torch.zeros(logits.shape[0], num_classes).to(logits.device)
+        # 256 -> 80, average for each class
+        # score aggregation method
+        if score_agg == 'MEAN':  # True
+            for label_j in positive_map:
+                scores[:, label_j] = logits[:,
+                                            torch.LongTensor(positive_map[label_j]
+                                                            )].mean(-1)
+        else:
+            raise NotImplementedError
+        return scores
+        
+    def _apply_exif_orientation(self, image):
+        """Applies the exif orientation correctly.
+
+        This code exists per the bug:
+        https://github.com/python-pillow/Pillow/issues/3973
+        with the function `ImageOps.exif_transpose`.
+        The Pillow source raises errors with
+        various methods, especially `tobytes`
+        Function based on:
+        https://github.com/facebookresearch/detectron2/\
+        blob/78d5b4f335005091fe0364ce4775d711ec93566e/\
+        detectron2/data/detection_utils.py#L119
+        Args:
+            image (PIL.Image): a PIL image
+        Returns:
+            (PIL.Image): the PIL image with exif orientation applied, if applicable
+        """
+        _EXIF_ORIENT = 274
+        if not hasattr(image, 'getexif'):
+            return image
+
+        try:
+            exif = image.getexif()
+        except Exception:
+            # https://github.com/facebookresearch/detectron2/issues/1885
+            exif = None
+
+        if exif is None:
+            return image
+
+        orientation = exif.get(_EXIF_ORIENT)
+
+        method = {
+            2: Image.FLIP_LEFT_RIGHT,
+            3: Image.ROTATE_180,
+            4: Image.FLIP_TOP_BOTTOM,
+            5: Image.TRANSPOSE,
+            6: Image.ROTATE_270,
+            7: Image.TRANSVERSE,
+            8: Image.ROTATE_90,
+        }.get(orientation)
+        if method is not None:
+            return image.transpose(method)
+        return image
+
+    def _create_positive_dict(self, tokenized, tokens_positive, labels):
+        """construct a dictionary such that positive_map[i] = j,
+        if token i is mapped to j label"""
+
+        positive_map_label_to_token = {}
+
+        for j, tok_list in enumerate(tokens_positive):
+            for (beg, end) in tok_list:
+                beg_pos = tokenized.char_to_token(beg)
+                end_pos = tokenized.char_to_token(end - 1)
+
+                assert beg_pos is not None and end_pos is not None
+                positive_map_label_to_token[labels[j]] = []
+                for i in range(beg_pos, end_pos + 1):
+                    positive_map_label_to_token[labels[j]].append(i)
+
+        return positive_map_label_to_token

--- a/fastdup/models/grounding_dino.py
+++ b/fastdup/models/grounding_dino.py
@@ -4,6 +4,7 @@ from fastdup.image import fastdup_imread
 from fastdup.sentry import fastdup_capture_exception
 from PIL import Image
 
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("fastdup.models.grounding_dino")
 

--- a/fastdup/models/grounding_dino.py
+++ b/fastdup/models/grounding_dino.py
@@ -106,6 +106,7 @@ class GroundingDINO:
     ):
         pred_dict = {}
         img = fastdup_imread(image_path, input_dir=None, kwargs=None)
+        img = img[:, :, ::-1]  # Convert to RGB
         image_pil = Image.fromarray(img)
         image_pil = self._apply_exif_orientation(image_pil)
         image, _ = grounding_dino_transform(image_pil, None)  # 3, h, w

--- a/fastdup/models/grounding_dino.py
+++ b/fastdup/models/grounding_dino.py
@@ -1,3 +1,7 @@
+import logging
+import os
+import subprocess
+
 try:
     from mmengine.config import Config
     from PIL import Image
@@ -6,82 +10,128 @@ try:
     import groundingdino.datasets.transforms as T
     from groundingdino.models import build_model
     from groundingdino.util import get_tokenlizer
-    from groundingdino.util.utils import (clean_state_dict,
-                                        get_phrases_from_posmap)
-    grounding_dino_transform = T.Compose([
-        T.RandomResize([800], max_size=1333),
-        T.ToTensor(),
-        T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
-    ])
+    from groundingdino.util.utils import clean_state_dict, get_phrases_from_posmap
+
+    grounding_dino_transform = T.Compose(
+        [
+            T.RandomResize([800], max_size=1333),
+            T.ToTensor(),
+            T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ]
+    )
 except ImportError as e:
     print(e)
-    installation = 'pip install mmengine ' \
-    'groundingdino-py ' \
-    'git+https://github.com/facebookresearch/segment-anything.git ' \
-    'scipy ' \
-    'git+https://github.com/open-mmlab/mmdetection.git ' \
-
+    installation = (
+        "pip install mmengine "
+        "groundingdino-py "
+        "git+https://github.com/facebookresearch/segment-anything.git "
+        "git+https://github.com/open-mmlab/mmdetection.git "
+    )
     print(f"Please install with {installation}")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("fastdup.models.grounding_dino")
 
 
 class GroundingDINO:
-    def __init__(self, 
-                 model_config:str = "GroundingDINO_SwinT_OGC.py", 
-                 model_weights:str = "groundingdino_swint_ogc.pth", 
-                 device:str="cuda"
-                 ) -> None:
+    def __init__(
+        self,
+        model_config: str = "GroundingDINO_SwinT_OGC.py",
+        model_weights: str = "groundingdino_swint_ogc.pth",
+        device: str = "cuda",
+    ) -> None:
         self.model_config = model_config
         self.model_weights = model_weights
         self.device = device
         self.model = self._load_model()
-    
+
+    def _download_file(self, target_path, download_url):
+        """Helper function to download a file if it doesn't exist."""
+        if not os.path.exists(target_path):
+            logger.info(f"File not found at {target_path}. Downloading from {download_url}...")
+            try:
+                subprocess.run(["wget", "-O", target_path, download_url], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, check=True)
+                logger.info("File downloaded successfully")
+            except subprocess.CalledProcessError:
+                logger.error(f"Error downloading file from {download_url}")
+                raise
+
     def _load_model(self):
+        """Load the model by downloading config and weights if necessary."""
+        # Download config file if not present
+        config_download_url = "https://raw.githubusercontent.com/open-mmlab/playground/main/mmdet_sam/configs/GroundingDINO_SwinT_OGC.py"
+        self._download_file(self.model_config, config_download_url)
+
+        # Download weights file if not present
+        weights_download_url = "https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth"
+        self._download_file(self.model_weights, weights_download_url)
+
+        # Load the model with the downloaded config and weights
+        logger.info(f"Loading model checkpoint - {self.model_weights}")
         gdino_args = Config.fromfile(self.model_config)
         model = build_model(gdino_args)
-        checkpoint = torch.load(self.model_weights, map_location='cpu')
-        model.load_state_dict(clean_state_dict(checkpoint['model']), strict=False)
+        
+        checkpoint = torch.load(self.model_weights, map_location=self.device)
+        
+        # Ensure the checkpoint contains the necessary "model" key
+        if "model" not in checkpoint:
+            logger.error("The model checkpoint does not contain the expected 'model' key.")
+            raise ValueError("Invalid checkpoint format")
+            
+        model.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
         model.eval()
         model.to(self.device)
         return model
-    
-    def run_inference(self, image_path, text_prompt, box_threshold=0.3, text_threshold=0.25, apply_original_groudingdino=False):
+
+    def run_inference(
+        self,
+        image_path,
+        text_prompt,
+        box_threshold=0.3,
+        text_threshold=0.25,
+        apply_original_groundingdino=False,
+    ):
         pred_dict = {}
-        image_pil = Image.open(image_path).convert('RGB')  # load image
+        image_pil = Image.open(image_path).convert("RGB")  # load image
         image_pil = self._apply_exif_orientation(image_pil)
         image, _ = grounding_dino_transform(image_pil, None)  # 3, h, w
 
         text_prompt = text_prompt.lower().strip()
-        if not text_prompt.endswith('.'):
-            text_prompt = text_prompt + '.'
+        if not text_prompt.endswith("."):
+            text_prompt = text_prompt + "."
 
         # Original GroundingDINO use text-thr to get class name,
         # the result will always result in categories that we don't want,
         # so we provide a category-restricted approach to address this
-        if not apply_original_groudingdino:
-            custom_vocabulary = text_prompt[:-1].split('.')
+        if not apply_original_groundingdino:
+            custom_vocabulary = text_prompt[:-1].split(".")
             label_name = [c.strip() for c in custom_vocabulary]
             tokens_positive = []
             start_i = 0
-            separation_tokens = ' . '
+            separation_tokens = " . "
             for _index, label in enumerate(label_name):
                 end_i = start_i + len(label)
                 tokens_positive.append([(start_i, end_i)])
                 if _index != len(label_name) - 1:
                     start_i = end_i + len(separation_tokens)
-            tokenizer = get_tokenlizer.get_tokenlizer('bert-base-uncased')
-            tokenized = tokenizer(text_prompt, padding='longest', return_tensors='pt')
-            positive_map_label_to_token = self._create_positive_dict(tokenized, tokens_positive, list(range(len(label_name))))
+            tokenizer = get_tokenlizer.get_tokenlizer("bert-base-uncased")
+            tokenized = tokenizer(text_prompt, padding="longest", return_tensors="pt")
+            positive_map_label_to_token = self._create_positive_dict(
+                tokenized, tokens_positive, list(range(len(label_name)))
+            )
 
         image = image.to(next(self.model.parameters()).device)
 
         with torch.no_grad():
             outputs = self.model(image[None], captions=[text_prompt])
 
-        logits = outputs['pred_logits'].cpu().sigmoid()[0]
-        boxes = outputs['pred_boxes'].cpu()[0]
+        logits = outputs["pred_logits"].cpu().sigmoid()[0]
+        boxes = outputs["pred_boxes"].cpu()[0]
 
-        if not apply_original_groudingdino:
-            logits = self._convert_grounding_to_od_logits(logits, len(label_name), positive_map_label_to_token)
+        if not apply_original_groundingdino:
+            logits = self._convert_grounding_to_od_logits(
+                logits, len(label_name), positive_map_label_to_token
+            )
 
         logits_filt = logits.clone()
         boxes_filt = boxes.clone()
@@ -89,15 +139,16 @@ class GroundingDINO:
         logits_filt = logits_filt[filt_mask]
         boxes_filt = boxes_filt[filt_mask]
 
-        if apply_original_groudingdino:
+        if apply_original_groundingdino:
             tokenlizer = self.model.tokenizer
             tokenized = tokenlizer(text_prompt)
             pred_labels = []
             pred_scores = []
             for logit, box in zip(logits_filt, boxes_filt):
-                pred_phrase = get_phrases_from_posmap(logit > text_threshold, tokenized, tokenlizer)
+                pred_phrase = get_phrases_from_posmap(logit > text_threshold,
+                                                      tokenized, tokenlizer)
                 pred_labels.append(pred_phrase)
-                pred_scores.append(round(float(score.item()), 4))
+                pred_scores.append(round(float(logit.max().item()), 4))
 
         else:
             scores, pred_phrase_idxs = logits_filt.max(1)
@@ -107,8 +158,8 @@ class GroundingDINO:
                 pred_labels.append(label_name[pred_phrase_idx])
                 pred_scores.append(round(float(score.item()), 4))
 
-        pred_dict['labels'] = pred_labels
-        pred_dict['scores'] = pred_scores
+        pred_dict["labels"] = pred_labels
+        pred_dict["scores"] = pred_scores
 
         size = image_pil.size
         H, W = size[1], size[0]
@@ -116,15 +167,16 @@ class GroundingDINO:
             boxes_filt[i] = boxes_filt[i] * torch.Tensor([W, H, W, H])
             boxes_filt[i][:2] -= boxes_filt[i][2:] / 2
             boxes_filt[i][2:] += boxes_filt[i][:2]
-        
-        pred_dict['boxes'] = [tuple(round(coord, 2) for coord in box) for box in boxes_filt.tolist()]
 
+        pred_dict["boxes"] = [
+            tuple(round(coord, 2) for coord in box) for box in boxes_filt.tolist()
+        ]
 
         return pred_dict
-    def _convert_grounding_to_od_logits(self, logits,
-                                    num_classes,
-                                    positive_map,
-                                    score_agg='MEAN'):
+
+    def _convert_grounding_to_od_logits(
+        self, logits, num_classes, positive_map, score_agg="MEAN"
+    ):
         """
         logits: (num_query, max_seq_len)
         num_classes: 80 for COCO
@@ -134,15 +186,15 @@ class GroundingDINO:
         scores = torch.zeros(logits.shape[0], num_classes).to(logits.device)
         # 256 -> 80, average for each class
         # score aggregation method
-        if score_agg == 'MEAN':  # True
+        if score_agg == "MEAN":  # True
             for label_j in positive_map:
-                scores[:, label_j] = logits[:,
-                                            torch.LongTensor(positive_map[label_j]
-                                                            )].mean(-1)
+                scores[:, label_j] = logits[
+                    :, torch.LongTensor(positive_map[label_j])
+                ].mean(-1)
         else:
             raise NotImplementedError
         return scores
-        
+
     def _apply_exif_orientation(self, image):
         """Applies the exif orientation correctly.
 
@@ -161,7 +213,7 @@ class GroundingDINO:
             (PIL.Image): the PIL image with exif orientation applied, if applicable
         """
         _EXIF_ORIENT = 274
-        if not hasattr(image, 'getexif'):
+        if not hasattr(image, "getexif"):
             return image
 
         try:
@@ -195,7 +247,7 @@ class GroundingDINO:
         positive_map_label_to_token = {}
 
         for j, tok_list in enumerate(tokens_positive):
-            for (beg, end) in tok_list:
+            for beg, end in tok_list:
                 beg_pos = tokenized.char_to_token(beg)
                 end_pos = tokenized.char_to_token(end - 1)
 

--- a/fastdup/models/grounding_dino.py
+++ b/fastdup/models/grounding_dino.py
@@ -11,7 +11,9 @@ try:
     import torch
 except ImportError as e:
     fastdup_capture_exception("enrichment_missing_dependencies", e, True)
-    logger.error("The `torch` package is not installed. Please run `pip install torch` or equivalent.")
+    logger.error(
+        "The `torch` package is not installed. Please run `pip install torch` or equivalent."
+    )
 
 try:
     from mmengine.config import Config
@@ -33,11 +35,11 @@ except ImportError as e:
     installation = (
         "`pip install mmengine "
         "groundingdino-py "
-        "git+https://github.com/facebookresearch/segment-anything.git "
         "git+https://github.com/open-mmlab/mmdetection.git` "
     )
-    logger.error(f"Your system is missing some dependencies. Please install with {installation}")
-
+    logger.error(
+        f"Your system is missing some dependencies. Please install with {installation}."
+    )
 
 
 # Download URLs

--- a/fastdup/models/ram.py
+++ b/fastdup/models/ram.py
@@ -22,37 +22,43 @@ except ImportError:
     )
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger('fastdup.models.ram')
+logger = logging.getLogger("fastdup.models.ram")
 
 
 class RecognizeAnythingModel:
-    def __init__(self, model_path:str='ram_swin_large_14m.pth', device:str='cuda') -> None:
+    def __init__(
+        self, model_path: str = "ram_swin_large_14m.pth", device: str = "cuda"
+    ) -> None:
         self.model_path = model_path
         self.device = device
         self.model = self._load_model()
-        
-    
+
     def _load_model(self) -> torch.nn.Module:
         if not os.path.exists(self.model_path):
-            download_url = 'https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/ram_swin_large_14m.pth'
-            logger.info(f"Model file not found. Downloading model from {download_url}...")
-            subprocess.run(['wget', '-O', self.model_path, download_url], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            download_url = "https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/ram_swin_large_14m.pth"
+            logger.info(
+                f"Model file not found. Downloading model from {download_url}..."
+            )
+            subprocess.run(
+                ["wget", "-O", self.model_path, download_url],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
             logger.info("Model downloaded.")
 
         logger.info(f"Loading model checkpoint - {self.model_path}")
-        
+
         # Hide the printing during model loading
         with contextlib.redirect_stdout(io.StringIO()):
-            model = ram(pretrained=self.model_path, image_size=384, vit='swin_l')
+            model = ram(pretrained=self.model_path, image_size=384, vit="swin_l")
             model.eval()
             model = model.to(self.device)
         logger.info(f"Model loaded to device - {self.device}")
         return model
-    
-    def run_inference(self, image_path:str) -> str:
+
+    def run_inference(self, image_path: str) -> str:
         transform = get_transform(image_size=384)
         image = transform(Image.open(image_path)).unsqueeze(0).to(self.device)
         results = inference_ram(image, self.model)
-        tags = results[0].replace(' | ', ' . ')
+        tags = results[0].replace(" | ", " . ")
         return tags
-    

--- a/fastdup/models/ram.py
+++ b/fastdup/models/ram.py
@@ -62,3 +62,13 @@ class RecognizeAnythingModel:
         results = inference_ram(image, self.model)
         tags = results[0].replace(" | ", " . ")
         return tags
+
+    def unload_model(self):
+        # Move the model to CPU
+        self.model.cpu()
+
+        # Remove model references
+        del self.model
+
+        # Explicitly clear CUDA cache
+        torch.cuda.empty_cache()

--- a/fastdup/models/ram.py
+++ b/fastdup/models/ram.py
@@ -1,14 +1,19 @@
 import logging
+from fastdup.utils import find_model
+from fastdup.image import fastdup_imread
+from fastdup.sentry import fastdup_capture_exception
 from PIL import Image
 import contextlib
 import io
-import os
-import subprocess
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("fastdup.models.ram")
 
 try:
     import torch
-except ImportError:
-    raise ImportError(
+except ImportError as e:
+    fastdup_capture_exception("enrichment_missing_dependencies", e, True)
+    logger.error(
         "The `torch` package is not installed. Please run `pip install torch` or equivalent."
     )
 
@@ -16,49 +21,55 @@ try:
     from ram.models import ram
     from ram import inference_ram
     from ram import get_transform
-except ImportError:
-    raise ImportError(
+except ImportError as e:
+    fastdup_capture_exception("enrichment_missing_dependencies", e, True)
+    logger.error(
         "The `recognize-anything` package is not installed. Please run `!pip install --upgrade setuptools && pip install -U git+https://github.com/xinyu1205/recognize-anything.git`."
     )
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("fastdup.models.ram")
+# Download URLs
+WEIGHTS_DOWNLOAD_URL = "https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/ram_swin_large_14m.pth"
 
 
 class RecognizeAnythingModel:
-    def __init__(
-        self, model_path: str = "ram_swin_large_14m.pth", device: str = "cuda"
-    ) -> None:
-        self.model_path = model_path
-        self.device = device
-        self.model = self._load_model()
+    def __init__(self, model_weights: str = None, device: str = None) -> None:
+        # If no config/weights provided, search on local path, if not found, download from URL
+        self.model_weights = (
+            model_weights
+            if model_weights is not None
+            else find_model("ram_swin_large_14m.pth", WEIGHTS_DOWNLOAD_URL)
+        )
+
+        # Pick available device if not specified.
+        if device is None:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            self.device = device
+
+        try:
+            self.model = self._load_model()
+        except Exception as e:
+            fastdup_capture_exception("model_checkpoint_corrupted", e, True)
+            logger.error(
+                f"Failed to load model checkpoint from {self.model_weights}. Verify the checkpoint file is not corrupted or re-download the model checkpoint."
+            )
 
     def _load_model(self) -> torch.nn.Module:
-        if not os.path.exists(self.model_path):
-            download_url = "https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/ram_swin_large_14m.pth"
-            logger.info(
-                f"Model file not found. Downloading model from {download_url}..."
-            )
-            subprocess.run(
-                ["wget", "-O", self.model_path, download_url],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-            )
-            logger.info("Model downloaded.")
-
-        logger.info(f"Loading model checkpoint - {self.model_path}")
+        logger.info(f"Loading model checkpoint from - {self.model_weights}")
 
         # Hide the printing during model loading
         with contextlib.redirect_stdout(io.StringIO()):
-            model = ram(pretrained=self.model_path, image_size=384, vit="swin_l")
+            model = ram(pretrained=self.model_weights, image_size=384, vit="swin_l")
             model.eval()
             model = model.to(self.device)
-        logger.info(f"Model loaded to device - {self.device}")
-        return model
+            logger.info(f"Model loaded to device - {self.device}")
+            return model
 
     def run_inference(self, image_path: str) -> str:
+        img = fastdup_imread(image_path, input_dir=None, kwargs=None)
+        image = Image.fromarray(img)
         transform = get_transform(image_size=384)
-        image = transform(Image.open(image_path)).unsqueeze(0).to(self.device)
+        image = transform(image).unsqueeze(0).to(self.device)
         results = inference_ram(image, self.model)
         tags = results[0].replace(" | ", " . ")
         return tags

--- a/fastdup/models/ram.py
+++ b/fastdup/models/ram.py
@@ -1,0 +1,58 @@
+import logging
+from PIL import Image
+import contextlib
+import io
+import os
+import subprocess
+
+try:
+    import torch
+except ImportError:
+    raise ImportError(
+        "The `torch` package is not installed. Please run `pip install torch` or equivalent."
+    )
+
+try:
+    from ram.models import ram
+    from ram import inference_ram
+    from ram import get_transform
+except ImportError:
+    raise ImportError(
+        "The `recognize-anything` package is not installed. Please run `!pip install --upgrade setuptools && pip install -U git+https://github.com/xinyu1205/recognize-anything.git`."
+    )
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('fastdup.models.ram')
+
+
+class RecognizeAnythingModel:
+    def __init__(self, model_path:str='ram_swin_large_14m.pth', device:str='cuda') -> None:
+        self.model_path = model_path
+        self.device = device
+        self.model = self._load_model()
+        
+    
+    def _load_model(self) -> torch.nn.Module:
+        if not os.path.exists(self.model_path):
+            download_url = 'https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/ram_swin_large_14m.pth'
+            logger.info(f"Model file not found. Downloading model from {download_url}...")
+            subprocess.run(['wget', '-O', self.model_path, download_url], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            logger.info("Model downloaded.")
+
+        logger.info(f"Loading model checkpoint - {self.model_path}")
+        
+        # Hide the printing during model loading
+        with contextlib.redirect_stdout(io.StringIO()):
+            model = ram(pretrained=self.model_path, image_size=384, vit='swin_l')
+            model.eval()
+            model = model.to(self.device)
+        logger.info(f"Model loaded to device - {self.device}")
+        return model
+    
+    def run_inference(self, image_path:str) -> str:
+        transform = get_transform(image_size=384)
+        image = transform(Image.open(image_path)).unsqueeze(0).to(self.device)
+        results = inference_ram(image, self.model)
+        tags = results[0].replace(' | ', ' . ')
+        return tags
+    

--- a/fastdup/models/ram.py
+++ b/fastdup/models/ram.py
@@ -67,6 +67,7 @@ class RecognizeAnythingModel:
 
     def run_inference(self, image_path: str) -> str:
         img = fastdup_imread(image_path, input_dir=None, kwargs=None)
+        img = img[:, :, ::-1]  # Convert to RGB
         image = Image.fromarray(img)
         transform = get_transform(image_size=384)
         image = transform(image).unsqueeze(0).to(self.device)

--- a/fastdup/models/sam.py
+++ b/fastdup/models/sam.py
@@ -61,13 +61,12 @@ class SegmentAnythingModel:
         return model
 
     def run_inference(self, image_path, bboxes):
-        image = fastdup_imread(image_path, input_dir=None, kwargs=None)
+        img = fastdup_imread(image_path, input_dir=None, kwargs=None)
         img = img[:, :, ::-1]  # Convert to RGB
-        # image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
-        self.model.set_image(image)
+        self.model.set_image(img)
         transformed_boxes = self.model.transform.apply_boxes_torch(
-            bboxes, image.shape[:2]
+            bboxes, img.shape[:2]
         )
         transformed_boxes = transformed_boxes.to(self.model.model.device)
 

--- a/fastdup/models/sam.py
+++ b/fastdup/models/sam.py
@@ -1,0 +1,77 @@
+try:
+    import torch
+except ImportError:
+    raise ImportError(
+        "The `torch` package is not installed. Please run `pip install torch` or equivalent."
+    )
+
+try:
+    from segment_anything import SamPredictor, sam_model_registry
+except ImportError:
+    raise ImportError(
+        "The `segment-anything` package is not installed. Please run `pip install git+https://github.com/facebookresearch/segment-anything.git`."
+    )
+
+
+import os
+import logging
+import subprocess
+import cv2
+import torch
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("fastdup.model.tag2text")
+
+
+class SegmentAnythingModel:
+    def __init__(
+        self, vit_type="vit_h", weights="sam_vit_h_4b8939.pth", device="cuda"
+    ) -> None:
+        self.vit_type = vit_type
+        self.weights = weights
+        self.device = device
+        self.model = self._load_model()
+
+    def _load_model(self):
+        if not os.path.exists(self.weights):
+            download_url = (
+                "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
+            )
+            logger.info(
+                f"Model file not found. Downloading model from {download_url}..."
+            )
+            subprocess.run(["wget", "-O", self.model_path, download_url])
+            logger.info("Model downloaded.")
+        build_sam = sam_model_registry[self.vit_type]
+        sam_model = SamPredictor(build_sam(checkpoint=self.weights))
+        sam_model.mode = sam_model.model.to(self.device)
+        return sam_model
+
+    def run_inference(self, image_path, bboxes):
+        image = cv2.imread(image_path)
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+        self.model.set_image(image)
+        transformed_boxes = self.model.transform.apply_boxes_torch(
+            bboxes, image.shape[:2]
+        )
+        transformed_boxes = transformed_boxes.to(self.model.model.device)
+
+        masks, _, _ = self.model.predict_torch(
+            point_coords=None,
+            point_labels=None,
+            boxes=transformed_boxes,
+            multimask_output=False,
+        )
+
+        return masks
+
+    def unload_model(self):
+        # Move the model to CPU
+        self.model.model.cpu()
+
+        # Remove model references
+        del self.model
+
+        # Explicitly clear CUDA cache
+        torch.cuda.empty_cache()

--- a/fastdup/models/sam.py
+++ b/fastdup/models/sam.py
@@ -40,7 +40,7 @@ class SegmentAnythingModel:
             logger.info(
                 f"Model file not found. Downloading model from {download_url}..."
             )
-            subprocess.run(["wget", "-O", self.model_path, download_url])
+            subprocess.run(["wget", "-O", self.weights, download_url])
             logger.info("Model downloaded.")
         build_sam = sam_model_registry[self.vit_type]
         sam_model = SamPredictor(build_sam(checkpoint=self.weights))

--- a/fastdup/models/sam.py
+++ b/fastdup/models/sam.py
@@ -62,7 +62,8 @@ class SegmentAnythingModel:
 
     def run_inference(self, image_path, bboxes):
         image = fastdup_imread(image_path, input_dir=None, kwargs=None)
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        img = img[:, :, ::-1]  # Convert to RGB
+        # image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
         self.model.set_image(image)
         transformed_boxes = self.model.transform.apply_boxes_torch(

--- a/fastdup/models/tag2text.py
+++ b/fastdup/models/tag2text.py
@@ -22,38 +22,51 @@ except ImportError:
     )
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger('fastdup.model.tag2text')
+logger = logging.getLogger("fastdup.model.tag2text")
+
 
 class Tag2TextModel:
-    def __init__(self, model_path:str='tag2text_swin_14m.pth', device:str='cuda') -> None:
+    def __init__(
+        self, model_path: str = "tag2text_swin_14m.pth", device: str = "cuda"
+    ) -> None:
         self.model_path = model_path
         self.device = device
         self.model = self._load_model()
-    
+
     def _load_model(self) -> torch.nn.Module:
         if not os.path.exists(self.model_path):
-            download_url = 'https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/tag2text_swin_14m.pth'
-            logger.info(f"Model file not found. Downloading model from {download_url}...")
-            subprocess.run(['wget', '-O', self.model_path, download_url], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            download_url = "https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/tag2text_swin_14m.pth"
+            logger.info(
+                f"Model file not found. Downloading model from {download_url}..."
+            )
+            subprocess.run(
+                ["wget", "-O", self.model_path, download_url],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )
             logger.info("Model downloaded.")
 
         logger.info(f"Loading model checkpoint - {self.model_path}")
-        
+
         # Hide the printing during model loading
         with contextlib.redirect_stdout(io.StringIO()):
-
             # delete some tags that may disturb captioning
             # 127: "quarter"; 2961: "back", 3351: "two"; 3265: "three"; 3338: "four"; 3355: "five"; 3359: "one"
-            delete_tag_index = [127,2961, 3351, 3265, 3338, 3355, 3359]
+            delete_tag_index = [127, 2961, 3351, 3265, 3338, 3355, 3359]
 
-            model = tag2text(pretrained=self.model_path, image_size=384, vit='swin_b', delete_tag_index=delete_tag_index)
+            model = tag2text(
+                pretrained=self.model_path,
+                image_size=384,
+                vit="swin_b",
+                delete_tag_index=delete_tag_index,
+            )
             model.threshold = 0.68
             model.eval()
             model = model.to(self.device)
         logger.info(f"Model loaded to device - {self.device}")
         return model
-    
-    def run_inference(self, image_path:str, user_tags='None') -> tuple:
+
+    def run_inference(self, image_path: str, user_tags="None") -> tuple:
         transform = get_transform(image_size=384)
         image = transform(Image.open(image_path)).unsqueeze(0).to(self.device)
         results = inference_tag2text(image, self.model, user_tags)

--- a/fastdup/models/tag2text.py
+++ b/fastdup/models/tag2text.py
@@ -1,0 +1,60 @@
+import logging
+from PIL import Image
+import contextlib
+import io
+import os
+import subprocess
+
+try:
+    import torch
+except ImportError:
+    raise ImportError(
+        "The `torch` package is not installed. Please run `pip install torch` or equivalent."
+    )
+
+try:
+    from ram.models import tag2text
+    from ram import inference_tag2text
+    from ram import get_transform
+except ImportError:
+    raise ImportError(
+        "The `recognize-anything` package is not installed. Please run `pip install --upgrade setuptools && pip install -U git+https://github.com/xinyu1205/recognize-anything.git`."
+    )
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('fastdup.model.tag2text')
+
+class Tag2TextModel:
+    def __init__(self, model_path:str='tag2text_swin_14m.pth', device:str='cuda') -> None:
+        self.model_path = model_path
+        self.device = device
+        self.model = self._load_model()
+    
+    def _load_model(self) -> torch.nn.Module:
+        if not os.path.exists(self.model_path):
+            download_url = 'https://huggingface.co/spaces/xinyu1205/Recognize_Anything-Tag2Text/resolve/main/tag2text_swin_14m.pth'
+            logger.info(f"Model file not found. Downloading model from {download_url}...")
+            subprocess.run(['wget', '-O', self.model_path, download_url], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            logger.info("Model downloaded.")
+
+        logger.info(f"Loading model checkpoint - {self.model_path}")
+        
+        # Hide the printing during model loading
+        with contextlib.redirect_stdout(io.StringIO()):
+
+            # delete some tags that may disturb captioning
+            # 127: "quarter"; 2961: "back", 3351: "two"; 3265: "three"; 3338: "four"; 3355: "five"; 3359: "one"
+            delete_tag_index = [127,2961, 3351, 3265, 3338, 3355, 3359]
+
+            model = tag2text(pretrained=self.model_path, image_size=384, vit='swin_b', delete_tag_index=delete_tag_index)
+            model.threshold = 0.68
+            model.eval()
+            model = model.to(self.device)
+        logger.info(f"Model loaded to device - {self.device}")
+        return model
+    
+    def run_inference(self, image_path:str, user_tags='None') -> tuple:
+        transform = get_transform(image_size=384)
+        image = transform(Image.open(image_path)).unsqueeze(0).to(self.device)
+        results = inference_tag2text(image, self.model, user_tags)
+        return results

--- a/fastdup/models/tag2text.py
+++ b/fastdup/models/tag2text.py
@@ -76,6 +76,7 @@ class Tag2TextModel:
 
     def run_inference(self, image_path: str, user_tags="None") -> tuple:
         img = fastdup_imread(image_path, input_dir=None, kwargs=None)
+        img = img[:, :, ::-1]  # Convert to RGB
         image = Image.fromarray(img)
         transform = get_transform(image_size=384)
         image = transform(image).unsqueeze(0).to(self.device)

--- a/fastdup/models/tag2text.py
+++ b/fastdup/models/tag2text.py
@@ -71,3 +71,13 @@ class Tag2TextModel:
         image = transform(Image.open(image_path)).unsqueeze(0).to(self.device)
         results = inference_tag2text(image, self.model, user_tags)
         return results
+
+    def unload_model(self):
+        # Move the model to CPU
+        self.model.cpu()
+
+        # Remove model references
+        del self.model
+
+        # Explicitly clear CUDA cache
+        torch.cuda.empty_cache()

--- a/fastdup/models/utils.py
+++ b/fastdup/models/utils.py
@@ -1,0 +1,139 @@
+import cv2
+import matplotlib.pyplot as plt
+from collections import defaultdict
+import json
+from PIL import Image
+import numpy as np
+
+def convert_to_coco_format(df, bbox_col, label_col, json_filename):
+    # Initialize COCO formatted dictionary
+    coco_format = defaultdict(list)
+
+    # Initialize counters for unique IDs
+    image_id = 0
+    annotation_id = 0
+
+    # Initialize a category set to keep track of unique categories
+    category_set = set()
+
+    # Iterate through each row in the DataFrame to populate the COCO dictionary
+    for _, row in df.iterrows():
+        # Add image information
+        image_id += 1
+
+        with Image.open(row["filename"]) as img:
+            width, height = img.size
+
+        image_info = {
+            "id": image_id,
+            "file_name": row["filename"],
+            "width": width,
+            "height": height,
+        }
+        coco_format["images"].append(image_info)
+
+        # Parse bounding boxes and labels
+        bboxes = row[bbox_col]
+        labels = row[label_col]
+
+        for bbox, label in zip(bboxes, labels):
+            # Update category set
+            category_set.add(label)
+
+            # Add annotation information
+            annotation_id += 1
+            x1, y1, x2, y2 = bbox
+            width = x2 - x1
+            height = y2 - y1
+            area = width * height
+
+            annotation_info = {
+                "id": annotation_id,
+                "image_id": image_id,
+                "category_id": label,  # Set to label name instead of None
+                "bbox": [x1, y1, width, height],
+                "area": area,
+                "iscrowd": 0,
+            }
+            coco_format["annotations"].append(annotation_info)
+
+    # Add categories to COCO format
+    for category_id, category_name in enumerate(sorted(list(category_set)), start=1):
+        category_info = {"id": category_id, "name": category_name}
+        coco_format["categories"].append(category_info)
+
+    # Update category IDs in annotations
+    category_map = {
+        name: idx for idx, name in enumerate(sorted(list(category_set)), start=1)
+    }
+    for annotation in coco_format["annotations"]:
+        annotation["category_id"] = category_map[annotation["category_id"]]
+
+    with open(json_filename, 'w') as f:
+        json.dump(coco_format, f)   
+
+
+def plot_annotations(df, image_col='filename', bbox_col=None, labels_col=None, scores_col=None, tags_col=None, masks_col=None, num_rows=5):
+    df = df.head(num_rows)
+    
+    if tags_col:
+        unique_tags = {tag for labels in df[tags_col] for tag in labels.replace(" ", "").split('.')}
+        cmap = plt.cm.get_cmap('hsv', len(unique_tags))
+        label_color_map = {label: cmap(idx)[:3] for idx, label in enumerate(sorted(unique_tags))}
+    else:
+        label_color_map = {}
+
+    num_subplots = 1  # always show original
+    if bbox_col:
+        num_subplots += 1
+    if masks_col:
+        num_subplots += 1
+
+    num_rows = len(df)
+    fig, axes = plt.subplots(num_rows, num_subplots, figsize=(6*num_subplots, 6*num_rows))
+    
+    if num_rows == 1:
+        axes = [axes]
+
+    for idx, (_, row) in enumerate(df.iterrows()):
+        # Read image
+        try:
+            image = cv2.imread(row[image_col])
+            image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        except Exception as e:
+            print(f"Error reading image {row[image_col]}: {e}")
+            continue
+        
+        # Original image
+        axes[idx][0].imshow(image_rgb)
+        axes[idx][0].set_title("Original Image")
+        axes[idx][0].axis('off')
+
+        subplot_idx = 1
+        
+        # Bounding boxes
+        if bbox_col:
+            axes[idx][subplot_idx].imshow(image_rgb)
+            axes[idx][subplot_idx].set_title("Annotated Boxes")
+            axes[idx][subplot_idx].axis('off')
+            for bbox, label, score in zip(row[bbox_col], row[labels_col], row[scores_col]):
+                x_min, y_min, x_max, y_max = bbox
+                edge_color = label_color_map.get(label, (1, 1, 1))
+                axes[idx][subplot_idx].add_patch(plt.Rectangle((x_min, y_min), x_max - x_min, y_max - y_min, linewidth=2, edgecolor=edge_color, facecolor='none'))
+                axes[idx][subplot_idx].text(x_min, y_min-5, f'{label} | {score:.2f}', color='white', bbox=dict(facecolor='black', edgecolor='black', boxstyle='round,pad=0.5'))
+            subplot_idx += 1
+        
+        # Masks
+        if masks_col:
+            axes[idx][subplot_idx].imshow(image_rgb)
+            axes[idx][subplot_idx].set_title("Annotated Masks")
+            axes[idx][subplot_idx].axis('off')
+            masks = row[masks_col].cpu().numpy()
+            for mask in masks:
+                color = np.concatenate([np.random.random(3), np.array([0.6])], axis=0)
+                h, w = mask.shape[-2:]
+                mask_image = mask.reshape(h, w, 1) * color.reshape(1, 1, -1)
+                axes[idx][subplot_idx].imshow(mask_image, alpha=0.9)
+
+    plt.tight_layout()
+    plt.show()


### PR DESCRIPTION
This PR adds zero shot models such as [Recognize Anything](https://github.com/xinyu1205/recognize-anything), [Tag2text](https://github.com/xinyu1205/recognize-anything), [Grounding DINO](https://github.com/IDEA-Research/GroundingDINO) and [Segment Anything](https://github.com/facebookresearch/segment-anything) models as an enrichment option for fastdup.

Here's a Colab notebook to run the following demo - https://colab.research.google.com/drive/1vTac7oTFIZ2eL1v-CDlSJTuCvbi3j0CB?usp=sharing

The enrichment API usage is as follows:

```python
import fastdup
fd = fastdup.create(input_dir='./coco_minitrain_25k')
fd.run()

# Enrich data with labels from Recognize Anything Model (RAM)
df = fd.enrich(task='zero-shot-classification', model='recognize-anything-model', num_rows=5)
```

Users can continue adding enrichment with other models by repeatedly calling the `.enrich` method and specifying an input dataframe. 

```python
# Enrich data with Grounding DINO model.
df = fd.enrich(task='zero-shot-detection', model='grounding-dino', input_df=df)
```

The dataframe will contain the enriched data

![image](https://github.com/visual-layer/fastdup/assets/6821286/30675f6e-b009-44f0-ae85-64d8373de69e)

The following is a plot using the labels generated by the models

![image](https://github.com/visual-layer/fastdup/assets/6821286/257d5a62-8caf-4ebd-b43c-f95525ea2a20)

User can continue to enrich data with Segment Anything model to generate masks from the Grounding DINO bounding boxes.

```python
df = fd.enrich(task='zero-shot-segmentation', model='segment-anything', input_df=df)
```
The results are as follows

![image](https://github.com/visual-layer/fastdup/assets/6821286/4562cda9-c4de-4650-a011-d1daf51d35bf)

