### PR TITLE
Temporary Fix for Download Badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [pypi-shield]: https://img.shields.io/badge/Python-3.7%20|%203.8%20|%203.9%20|%203.10-blue?style=for-the-badge
 [pypi-url]: https://pypi.org/project/fastdup/
 [pypiversion-shield]: https://img.shields.io/pypi/v/fastdup?style=for-the-badge&color=success
-[downloads-shield]: https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=downloads&query=%24.total_downloads&url=https%3A%2F%2Fapi.pepy.tech%2Fapi%2Fv2%2Fprojects%2Ffastdup&color=lightblue
+[downloads-shield]: https://img.shields.io/pypi/dm/fastdup?style=for-the-badge&color=lightblue
 [downloads-url]: https://pypi.org/project/fastdup/
 [contributors-shield]: https://img.shields.io/github/contributors/visual-layer/fastdup?style=for-the-badge&color=orange
 [contributors-url]: https://github.com/othneildrew/Best-README-Template/graphs/contributors


### PR DESCRIPTION
Due to a recent change by PePy, an API key is now required to access the "Total Downloads" data for packages, which has resulted in our "Total Downloads" badge on the README.md no longer displaying this information.

**Current Issue**:
The current badge setup is unable to retrieve the "Total Downloads" count, leading to a broken badge image.

![img](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=downloads&query=%24.total_downloads&url=https%3A%2F%2Fapi.pepy.tech%2Fapi%2Fv2%2Fprojects%2Ffastdup&color=lightblue)

**Temporary Solution**:
While PePy and shields.io work on a solution to display "Total Downloads" again, this PR implements a stop-gap measure by switching to a "Monthly Downloads" badge. This will ensure that we continue to provide download metrics on our README.

![img](https://img.shields.io/pypi/dm/fastdup?style=for-the-badge&color=lightblue)

**Proposed Change**:
Replace the existing badge with a "Monthly Downloads" badge, which does not require an API key and is fully functional.

We intend to revert to the "Total Downloads" badge as soon as PePy provides a method to do so that is compatible with our project's setup.