### PR TITLE
Fix CSS error in html_writer.py

### DIFF
--- a/fastdup/html_writer.py
+++ b/fastdup/html_writer.py
@@ -416,7 +416,7 @@ line-height: 1;
 position: absolute;
 margin: 0;
 bottom: 0;
-wifth: 150px
+width: 150px;
 right: 59px;
 }
 


### PR DESCRIPTION
Fixes a typo in `fastdup/html_writer.py` L#419.